### PR TITLE
Update python version of lambda to 3.7

### DIFF
--- a/source/templates/Viewer.template
+++ b/source/templates/Viewer.template
@@ -183,7 +183,7 @@ Resources:
       Handler: index.generate_cert
       MemorySize: 128
       Role: !Ref LambdaACMIAMRoleArn
-      Runtime: python3.6
+      Runtime: python3.7
       Timeout: 60
       Tags:
         - Key: soca:ClusterId


### PR DESCRIPTION
Python 3.6 is EOL and support for Lambda ends on 8/17/2022.

Resolves [Bug #8](https://github.com/awslabs/collaboration-chambers-on-aws/issues/8)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
